### PR TITLE
comparedate gnu stat vs bsd stat

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 ```
 # one liner
-curl -o ~/.config/direnv/helpers.sh --create-dirs https://raw.githubusercontent.com/steve-ross/direnv-helpers/master/helpers.sh && echo -n "source ~/.config/direnv/helpers.sh >> ~/.config/direnv/direnvrc
+curl -o ~/.config/direnv/helpers.sh --create-dirs https://raw.githubusercontent.com/steve-ross/direnv-helpers/master/helpers.sh && echo -n "source ~/.config/direnv/helpers.sh" >> ~/.config/direnv/direnvrc
 
 # OR...
 # download the script

--- a/helpers.sh
+++ b/helpers.sh
@@ -149,7 +149,11 @@ _log() {
 function comparedate() {
   local MAXAGE=$(bc <<< '24*60*60') # seconds in 24 hours
   # file age in seconds = current_time - file_modification_time.
-  local FILEAGE=$(($(date +%s) - $(stat -f '%m' "$1")))
+  if [ $(uname -s) == "Darwin" ]; then
+    local FILEAGE=$(($(date +%s) - $(stat -f '%m' "$1")))
+  else
+    local FILEAGE=$(($(date +%s) - $(stat -c '%Y' "$1")))
+  fi
   test $FILEAGE -gt $MAXAGE && {
       echo "Time to check for an update..."
   }


### PR DESCRIPTION
GNU stat on linux uses -C "%Y" to pull file age rather than -f "c". This patch detects the OS using uname -s and uses the appropriate arguments. (I don't have access to Mac OS to test, so apologies if this fails there.)