### PR TITLE
Update helpers.sh in order to keep compatibility with zsh too

### DIFF
--- a/helpers.sh
+++ b/helpers.sh
@@ -125,7 +125,7 @@ _log() {
 function comparedate() {
   local MAXAGE=$(bc <<< '24*60*60') # seconds in 24 hours
   # file age in seconds = current_time - file_modification_time.
-  if [ $(uname -s) == "Darwin" ]; then
+  if [[ $(uname -s) == "Darwin" ]]; then
     local FILEAGE=$(($(date +%s) - $(stat -f '%m' "$1")))
   else
     local FILEAGE=$(($(date +%s) - $(stat -c '%Y' "$1")))


### PR DESCRIPTION
Fix function in order to keep compatibility with zsh. 
Show case of the issue:
```
➜  bash -c "if [ \$(uname -s) == "Linux" ]; then echo 'yes sir, no Darwin here'; fi"
yes sir, no Darwin here
➜  zsh -c "if [ \$(uname -s) == "Linux" ]; then echo 'yes sir, no Darwin here'; fi"
zsh:1: = not found
```
After the fix:
```
➜  bash -c "if [[ \$(uname -s) == "Linux" ]]; then echo 'yes sir, no Darwin here'; fi"
yes sir, no Darwin here
➜  zsh -c "if [[ \$(uname -s) == "Linux" ]]; then echo 'yes sir, no Darwin here'; fi"
yes sir, no Darwin here
```
