### PR TITLE
Fixed missing quote in install command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ curl -o ~/.config/direnv/helpers.sh --create-dirs https://raw.githubusercontent.
 
 2. Source it in your ~/.config/direnv/direnvrc
 ```
-echo -n "source ~/.config/direnv/helpers.sh >> ~/.config/direnv/direnvrc
+echo -n "source ~/.config/direnv/helpers.sh" >> ~/.config/direnv/direnvrc
 ```
 
 ## How to use the helpers in your projects (NVM example)


### PR DESCRIPTION
README.md has a tiny typo ... The step 2 of installation is missing a double quote.